### PR TITLE
Add link to quadcopter workshop

### DIFF
--- a/workshops/quadcopter/README.md
+++ b/workshops/quadcopter/README.md
@@ -1,0 +1,6 @@
+# Devoxx4Kids quadcopter workshops
+
+This is just a link to the description and the repository for the Devoxx4Kids quadcopter workshop.
+You can find all information here:
+
+https://github.com/derTobsch/ardrone-autonomy-d4k


### PR DESCRIPTION
This only provides a link to the devoxx4kids quadcopter workshop. So everything will up-to-date and it is easy to setup the workshop independent from the other materials.