### PR TITLE
Update readme-forge.asciidoc

### DIFF
--- a/workshops/minecraft/readme-forge.asciidoc
+++ b/workshops/minecraft/readme-forge.asciidoc
@@ -130,13 +130,13 @@ This mod variation produces different items for different chat text. For example
 ----
 @SubscribeEvent
 public void giveItems(ServerChatEvent event){
-	if (event.getMessage().contains("potato")) {
-		event.getPlayer().inventory.addItemStackToInventory(new ItemStack(Items.POTATO, 64));
-	}
-	
-	if (event.getMessage().contains("diamond")) {
-		event.getPlayer().inventory.addItemStackToInventory(new ItemStack(Items.DIAMOND, 64));
-	}
+    	if (event.getMessage().contains("potato")) {
+    		event.getPlayer().getInventory().add(new ItemStack(Items.POTATO, 64));
+    	}
+
+    	if (event.getMessage().contains("diamond")) {
+    		event.getPlayer().getInventory().add(new ItemStack(Items.DIAMOND, 64));
+    	}
 }
 ----
 ====
@@ -153,8 +153,8 @@ This mod will produce multiple items for a chat text. Instead of only producing 
 @SubscribeEvent
 public void giveItems(ServerChatEvent event){
 	if (event.getMessage().contains("potato")) {
-		event.getPlayer().inventory.addItemStackToInventory(new ItemStack(Items.POTATO, 64));
-		event.getPlayer().inventory.addItemStackToInventory(new ItemStack(Items.DIAMOND, 64));
+		event.getPlayer().getInventory().add(new ItemStack(Items.POTATO, 64));
+		event.getPlayer().getInventory().add(new ItemStack(Items.DIAMOND, 64));
 	}
 }
 ----


### PR DESCRIPTION
fixed examples that still tried to access Player.inventory directly and still used the old addItemStackToInventory method that no longer exists.